### PR TITLE
chore: automate stable npm releases with workflow, guide, and PR template

### DIFF
--- a/.github/NPM_PUBLISHING_GUIDE.md
+++ b/.github/NPM_PUBLISHING_GUIDE.md
@@ -9,11 +9,13 @@ The package is configured to be published to npm similar to `@openzeppelin/contr
 ## Setup Requirements
 
 ### 1. NPM Account and Package Access
+
 - Create an npm account at https://www.npmjs.com/signup
 - Request access to the `@fevertokens` scope or create it
 - Generate an npm access token with publish permissions
 
 ### 2. GitHub Repository Configuration
+
 1. Go to your GitHub repository Settings → Secrets and variables → Actions
 2. Add a new repository secret:
    - Name: `NPM_TOKEN`
@@ -34,6 +36,7 @@ Use the GitHub Actions workflow for consistent, automated releases:
 5. Click "Run workflow"
 
 The workflow automatically:
+
 - ✅ Validates version format
 - ✅ Installs dependencies
 - ✅ Compiles Solidity contracts
@@ -96,12 +99,14 @@ npm link @fevertokens/packages
 ```
 
 **Advantages of npm link:**
+
 - ✅ Changes are reflected immediately (no need to rebuild/repack)
 - ✅ Great for active development
 - ✅ Easy to set up and tear down
 - ✅ Works like the real npm package
 
 **To unlink when done:**
+
 ```bash
 # In your test project
 npm unlink @fevertokens/packages
@@ -128,6 +133,7 @@ npm install /Users/youssef/Public/project/feverToken/@ft/packages/fevertokens-pa
 ```
 
 **When to use npm pack:**
+
 - ✅ Final verification before publishing
 - ✅ Testing the exact published package contents
 - ✅ Sharing with others without npm registry
@@ -138,23 +144,23 @@ npm install /Users/youssef/Public/project/feverToken/@ft/packages/fevertokens-pa
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.26;
 
-import "@fevertokens/packages/contracts/token/ERC20/IERC20.sol";
-import "@fevertokens/packages/contracts/security/ReentrancyGuard.sol";
-import "@fevertokens/packages/contracts/diamond/base/DiamondBase.sol";
+import '@fevertokens/packages/contracts/token/ERC20/IERC20.sol';
+import '@fevertokens/packages/contracts/security/ReentrancyGuard.sol';
+import '@fevertokens/packages/contracts/diamond/base/DiamondBase.sol';
 
 contract MyToken is IERC20 {
-    // Your implementation
+  // Your implementation
 }
 ```
 
 ### Comparison: npm link vs npm pack
 
-| Feature | npm link | npm pack |
-|---------|----------|----------|
-| **Use case** | Active development | Final testing |
-| **Updates** | Instant | Manual repack needed |
-| **Setup** | Quick symlink | Install tarball |
-| **Accuracy** | Development version | Exact published version |
+| Feature      | npm link              | npm pack                 |
+| ------------ | --------------------- | ------------------------ |
+| **Use case** | Active development    | Final testing            |
+| **Updates**  | Instant               | Manual repack needed     |
+| **Setup**    | Quick symlink         | Install tarball          |
+| **Accuracy** | Development version   | Exact published version  |
 | **Best for** | Iterative development | Pre-publish verification |
 
 ### Dry Run Publishing
@@ -170,13 +176,17 @@ This shows exactly what files will be included in the package.
 ## Package Configuration
 
 ### Files Included in Package
+
 Defined in `package.json` `files` field:
+
 - `/contracts/**/*.sol` - All Solidity contracts
 - `/LICENSE` - Apache 2.0 license
 - `/README.md` - Package documentation
 
 ### Files Excluded from Package
+
 Defined in `.npmignore`:
+
 - Development configuration files
 - Build artifacts (cache, artifacts, typechain)
 - GitHub workflows and scripts
@@ -193,6 +203,7 @@ Follow [Semantic Versioning](https://semver.org/):
 - **PATCH** (0.0.X): Bug fixes, backward compatible
 
 Example progression:
+
 ```
 1.0.0 → Initial release
 1.0.1 → Bug fix in ReentrancyGuard
@@ -212,20 +223,24 @@ After successful publishing:
 ## Troubleshooting
 
 ### "You do not have permission to publish"
+
 - Ensure your npm account has access to `@fevertokens` scope
 - Check that `NPM_TOKEN` secret is properly configured
 - Verify token has publish permissions
 
 ### "Version already exists"
+
 - You cannot republish the same version
 - Bump version number: `npm version patch`
 - Or unpublish if within 24 hours: `npm unpublish @fevertokens/packages@1.0.0`
 
 ### "Compilation errors"
+
 - Fix Solidity compilation issues: `npm run compile`
 - Check for syntax errors: `npm run lint:sol`
 
 ### "Format check failed"
+
 - Run formatter: `npm run format`
 - Verify: `npm run format:check`
 

--- a/.github/NPM_PUBLISHING_GUIDE.md
+++ b/.github/NPM_PUBLISHING_GUIDE.md
@@ -1,0 +1,254 @@
+# NPM Publishing Guide
+
+This guide explains how to publish `@fevertokens/packages` to npm for use as a smart contract library.
+
+## Overview
+
+The package is configured to be published to npm similar to `@openzeppelin/contracts`, allowing developers to install and import FeverTokens contracts in their projects.
+
+## Setup Requirements
+
+### 1. NPM Account and Package Access
+- Create an npm account at https://www.npmjs.com/signup
+- Request access to the `@fevertokens` scope or create it
+- Generate an npm access token with publish permissions
+
+### 2. GitHub Repository Configuration
+1. Go to your GitHub repository Settings → Secrets and variables → Actions
+2. Add a new repository secret:
+   - Name: `NPM_TOKEN`
+   - Value: Your npm access token
+
+## Publishing Methods
+
+### Method 1: Automated Publishing (Recommended)
+
+Use the GitHub Actions workflow for consistent, automated releases:
+
+1. Navigate to the Actions tab in GitHub
+2. Select "Publish Stable Release" workflow
+3. Click "Run workflow"
+4. Fill in the inputs:
+   - **Version**: Semantic version number (e.g., `1.0.0`, `1.2.3`)
+   - **Release notes**: Optional description of changes
+5. Click "Run workflow"
+
+The workflow automatically:
+- ✅ Validates version format
+- ✅ Installs dependencies
+- ✅ Compiles Solidity contracts
+- ✅ Runs linters and format checks
+- ✅ Publishes to npm with `--access public`
+- ✅ Creates git tag and GitHub release
+- ✅ Pushes version bump to main branch
+
+### Method 2: Manual Publishing
+
+For local testing or manual releases:
+
+```bash
+# 1. Ensure clean working directory
+git status
+
+# 2. Compile contracts
+npm run compile
+
+# 3. Run quality checks
+npm run lint
+npm run format:check
+
+# 4. Test the package locally (optional but recommended)
+npm pack
+# This creates a .tgz file you can test in another project:
+# npm install /path/to/fevertokens-packages-1.0.0.tgz
+
+# 5. Update version (follows semantic versioning)
+npm version patch   # 1.0.0 → 1.0.1
+npm version minor   # 1.0.0 → 1.1.0
+npm version major   # 1.0.0 → 2.0.0
+# Or specify exact version:
+npm version 1.2.3
+
+# 6. Publish to npm
+npm publish --access public
+
+# 7. Push changes and tags
+git push origin main --follow-tags
+```
+
+## Testing Before Publishing
+
+### Local Package Testing with npm link (Recommended for Development)
+
+Use `npm link` to create a symlink for active development and testing:
+
+```bash
+# 1. In the @fevertokens/packages directory, create a global symlink
+cd /Users/youssef/Public/project/feverToken/@ft/packages
+npm link
+
+# 2. In your test project, link to the package
+cd /path/to/your-test-project
+npm link @fevertokens/packages
+
+# 3. Now you can import and use the contracts
+# Any changes to the contracts will be immediately available
+```
+
+**Advantages of npm link:**
+- ✅ Changes are reflected immediately (no need to rebuild/repack)
+- ✅ Great for active development
+- ✅ Easy to set up and tear down
+- ✅ Works like the real npm package
+
+**To unlink when done:**
+```bash
+# In your test project
+npm unlink @fevertokens/packages
+
+# In the @fevertokens/packages directory (optional)
+npm unlink
+```
+
+### Local Package Testing with npm pack (For Final Verification)
+
+Use `npm pack` to test exactly what will be published:
+
+```bash
+# 1. In the @fevertokens/packages directory
+npm pack
+
+# This creates: fevertokens-packages-0.0.1.tgz
+
+# 2. In a test project, install the tarball
+cd /path/to/your-test-project
+npm install /Users/youssef/Public/project/feverToken/@ft/packages/fevertokens-packages-0.0.1.tgz
+
+# 3. Test importing contracts
+```
+
+**When to use npm pack:**
+- ✅ Final verification before publishing
+- ✅ Testing the exact published package contents
+- ✅ Sharing with others without npm registry
+
+### Test Project Example
+
+```solidity
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "@fevertokens/packages/contracts/token/ERC20/IERC20.sol";
+import "@fevertokens/packages/contracts/security/ReentrancyGuard.sol";
+import "@fevertokens/packages/contracts/diamond/base/DiamondBase.sol";
+
+contract MyToken is IERC20 {
+    // Your implementation
+}
+```
+
+### Comparison: npm link vs npm pack
+
+| Feature | npm link | npm pack |
+|---------|----------|----------|
+| **Use case** | Active development | Final testing |
+| **Updates** | Instant | Manual repack needed |
+| **Setup** | Quick symlink | Install tarball |
+| **Accuracy** | Development version | Exact published version |
+| **Best for** | Iterative development | Pre-publish verification |
+
+### Dry Run Publishing
+
+Test the publishing process without actually publishing:
+
+```bash
+npm publish --dry-run
+```
+
+This shows exactly what files will be included in the package.
+
+## Package Configuration
+
+### Files Included in Package
+Defined in `package.json` `files` field:
+- `/contracts/**/*.sol` - All Solidity contracts
+- `/LICENSE` - Apache 2.0 license
+- `/README.md` - Package documentation
+
+### Files Excluded from Package
+Defined in `.npmignore`:
+- Development configuration files
+- Build artifacts (cache, artifacts, typechain)
+- GitHub workflows and scripts
+- Test files
+- Node modules
+- Local environment files
+
+## Version Management
+
+Follow [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (X.0.0): Breaking changes to contract interfaces
+- **MINOR** (0.X.0): New features, backward compatible
+- **PATCH** (0.0.X): Bug fixes, backward compatible
+
+Example progression:
+```
+1.0.0 → Initial release
+1.0.1 → Bug fix in ReentrancyGuard
+1.1.0 → Add new ERC20 extension
+2.0.0 → Breaking change to Diamond architecture
+```
+
+## Post-Publishing
+
+After successful publishing:
+
+1. **Verify on npm**: https://www.npmjs.com/package/@fevertokens/packages
+2. **Test installation**: `npm install @fevertokens/packages`
+3. **Update documentation**: Ensure README and examples reflect latest version
+4. **Announce release**: Update users about new features/fixes
+
+## Troubleshooting
+
+### "You do not have permission to publish"
+- Ensure your npm account has access to `@fevertokens` scope
+- Check that `NPM_TOKEN` secret is properly configured
+- Verify token has publish permissions
+
+### "Version already exists"
+- You cannot republish the same version
+- Bump version number: `npm version patch`
+- Or unpublish if within 24 hours: `npm unpublish @fevertokens/packages@1.0.0`
+
+### "Compilation errors"
+- Fix Solidity compilation issues: `npm run compile`
+- Check for syntax errors: `npm run lint:sol`
+
+### "Format check failed"
+- Run formatter: `npm run format`
+- Verify: `npm run format:check`
+
+## Best Practices
+
+1. **Always test locally** before publishing
+2. **Use GitHub Actions** for consistency
+3. **Write meaningful release notes**
+4. **Follow semantic versioning strictly**
+5. **Never publish** with uncommitted changes
+6. **Review published files** with `npm pack` or `--dry-run`
+7. **Keep CHANGELOG** updated with version history
+
+## Security Considerations
+
+- **Never commit** npm tokens or credentials
+- **Use npm tokens** with least required permissions (publish-only)
+- **Enable 2FA** on your npm account
+- **Review dependencies** before publishing
+- **Audit contracts** before major releases
+
+## Resources
+
+- npm documentation: https://docs.npmjs.com/
+- Semantic Versioning: https://semver.org/
+- Package.json reference: https://docs.npmjs.com/cli/v10/configuring-npm/package-json

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,79 @@
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+
+<!-- Mark the relevant option with an "x" -->
+
+- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
+- [ ] ✨ New feature (non-breaking change which adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] 📝 Documentation update
+- [ ] 🎨 Code style update (formatting, renaming)
+- [ ] ♻️ Refactoring (no functional changes)
+- [ ] ⚡️ Performance improvement
+- [ ] ✅ Test update
+- [ ] 🔧 Configuration change
+- [ ] 🔨 Build/CI update
+
+## Related Issue
+
+<!-- Link to the issue this PR addresses -->
+
+Closes #
+
+## Changes Made
+
+<!-- List the main changes made in this PR -->
+
+-
+-
+-
+
+## Testing
+
+<!-- Describe the tests you ran to verify your changes -->
+
+### Test Coverage
+
+- [ ] All tests pass (`npm test`)
+- [ ] New tests added for new functionality
+- [ ] Coverage maintained or improved
+
+### Manual Testing
+
+<!-- Describe manual testing performed -->
+
+- [ ] Tested locally
+- [ ] Tested with example manifests
+- [ ] Tested edge cases
+
+## Screenshots/Examples
+
+<!-- If applicable, add screenshots or example output -->
+
+```yaml
+# Example manifest or code snippet
+```
+
+## Checklist
+
+<!-- Mark completed items with an "x" -->
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Breaking Changes
+
+<!-- If this is a breaking change, describe the impact and migration path -->
+
+## Additional Notes
+
+<!-- Add any additional notes, context, or concerns -->

--- a/.github/RELEASE_GUIDE.md
+++ b/.github/RELEASE_GUIDE.md
@@ -1,0 +1,66 @@
+# Quick Release Guide
+
+## ✅ Publish Stable Release
+
+1. Go to **Actions** → **Publish Stable Release**
+2. Click **Run workflow**
+3. Enter:
+   - **Version**: `X.Y.Z` (e.g., `0.1.0`, `1.0.0`)
+   - **Release notes**: Optional markdown
+4. Click **Run workflow**
+
+**Result:** Published to npm with `@latest` tag
+
+**Install:**
+
+```bash
+npm install -g @fevertokens/packages
+```
+
+---
+
+## 📋 Required Setup (One-time)
+
+### 1. Add NPM_TOKEN Secret
+
+1. Generate npm token: https://www.npmjs.com/settings/YOUR_USERNAME/tokens
+   - Type: **Automation**
+   - Scope: **Read and write**
+2. Go to GitHub: **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Name: `NPM_TOKEN`
+5. Value: Paste your token
+6. Click **Add secret**
+
+### 2. Verify Permissions
+
+- npm account must have publish access to `@fevertokens/packages`
+- GitHub Actions must have write permissions (Settings → Actions → General)
+
+---
+
+## 📦 Version Examples
+
+### Semantic Versioning
+
+- **Patch**: `0.0.14` → `0.0.15` (bug fixes)
+- **Minor**: `0.0.15` → `0.1.0` (new features)
+- **Major**: `0.1.0` → `1.0.0` (breaking changes)
+
+---
+
+## ⚡ Quick Commands
+
+```bash
+# Install latest stable
+npm install -g @fevertokens/packages
+
+# Install specific version
+npm install -g @fevertokens/packages@0.1.0
+
+# Check version
+fever --version
+
+# View available versions
+npm view @fevertokens/packages versions
+```

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -1,0 +1,110 @@
+name: Publish Release Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g., 0.1.0, 1.0.0)'
+        required: true
+        type: string
+      rcversion:
+        description: 'RC version number (e.g., 1, 2, 3, 4...)'
+        required: true
+        type: string
+      release_notes:
+        description: 'Release notes (optional)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must follow semantic versioning (e.g., 0.1.0, 1.0.0)"
+            exit 1
+          fi
+          if ! [[ "${{ inputs.rcversion }}" =~ ^[0-9]+$ ]]; then
+            echo "Error: RC version must be a number (e.g., 1, 2, 3, 4)"
+            exit 1
+          fi
+
+      - name: Build full version string
+        id: full_version
+        run: echo "version=${{ inputs.version }}-rc.${{ inputs.rcversion }}" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile contracts
+        run: npm run compile
+
+      - name: Check code formatting
+        run: npm run format:check
+
+      - name: Run linters
+        run: npm run lint
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update version
+        run: npm version ${{ steps.full_version.outputs.version }} --no-git-tag-version
+
+      - name: Publish to npm with next tag
+        run: npm publish --access public --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Commit version change
+        run: |
+          git add package.json package-lock.json
+          git commit -m "chore: release candidate v${{ steps.full_version.outputs.version }}" || echo "No changes to commit"
+
+      - name: Create and push tag
+        run: |
+          git tag -a "v${{ steps.full_version.outputs.version }}" -m "Release candidate v${{ steps.full_version.outputs.version }}"
+          git push origin "v${{ steps.full_version.outputs.version }}"
+
+      - name: Create GitHub Pre-Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.full_version.outputs.version }}
+          release_name: v${{ steps.full_version.outputs.version }}
+          body: |
+            ## Release Candidate
+
+            This is a pre-release version for testing purposes.
+
+            **Installation:**
+            ```bash
+            npm install @fevertokens/packages@next
+            # or specific version
+            npm install @fevertokens/packages@${{ steps.full_version.outputs.version }}
+            ```
+
+            ${{ inputs.release_notes }}
+          draft: false
+          prerelease: true

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -71,8 +71,8 @@ jobs:
       - name: Update version
         run: npm version ${{ steps.full_version.outputs.version }} --no-git-tag-version
 
-      - name: Publish to npm with next tag
-        run: npm publish --access public --tag next
+      - name: Publish to npm with rc tag
+        run: npm publish --access public --tag rc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -100,7 +100,7 @@ jobs:
 
             **Installation:**
             ```bash
-            npm install @fevertokens/packages@next
+            npm install @fevertokens/packages@rc
             # or specific version
             npm install @fevertokens/packages@${{ steps.full_version.outputs.version }}
             ```

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -87,12 +87,10 @@ jobs:
           git push origin "v${{ steps.full_version.outputs.version }}"
 
       - name: Create GitHub Pre-Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.full_version.outputs.version }}
-          release_name: v${{ steps.full_version.outputs.version }}
+          name: v${{ steps.full_version.outputs.version }}
           body: |
             ## Release Candidate
 

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -71,12 +71,10 @@ jobs:
           git push origin "v${{ github.event.inputs.version }}"
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ github.event.inputs.version }}
-          release_name: v${{ github.event.inputs.version }}
+          name: v${{ github.event.inputs.version }}
           body: |
             ## v${{ github.event.inputs.version }}
 

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -1,0 +1,107 @@
+name: Publish Stable Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version number (e.g., 0.1.0, 1.0.0)"
+        required: true
+        type: string
+      release-notes:
+        description: "Release notes (optional)"
+        required: false
+        type: string
+
+jobs:
+  publish-stable:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Validate version format
+        run: |
+          if ! echo "${{ github.event.inputs.version }}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "❌ Invalid version format. Use semantic versioning (e.g., 1.0.0)"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update package.json version
+        run: |
+          npm version ${{ github.event.inputs.version }} --no-git-tag-version
+
+      - name: Build
+        run: npm run build
+
+      - name: Run checks
+        run: npm run check
+
+      - name: Publish to npm (latest tag)
+        run: npm publish --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: bump version to ${{ github.event.inputs.version }}"
+          git tag -a "v${{ github.event.inputs.version }}" -m "Release v${{ github.event.inputs.version }}"
+          git push origin main
+          git push origin "v${{ github.event.inputs.version }}"
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          release_name: v${{ github.event.inputs.version }}
+          body: |
+            ## v${{ github.event.inputs.version }}
+
+            ### Installation
+            ```bash
+            npm install -g @fevertokens/packages
+            # Or specific version
+            npm install -g @fevertokens/packages@${{ github.event.inputs.version }}
+            ```
+
+            ### Verify Installation
+            ```bash
+            fever --version
+            ```
+
+            ${{ github.event.inputs.release-notes }}
+
+            **Full Changelog**: https://github.com/${{ github.repository }}/commits/v${{ github.event.inputs.version }}
+          draft: false
+          prerelease: false
+
+      - name: Output success message
+        run: |
+          echo "✅ Successfully published stable version: ${{ github.event.inputs.version }}"
+          echo ""
+          echo "📦 Install with:"
+          echo "   npm install -g @fevertokens/packages"
+          echo "   npm install -g @fevertokens/packages@${{ github.event.inputs.version }}"
+          echo ""
+          echo "🔗 GitHub Release: https://github.com/${{ github.repository }}/releases/tag/v${{ github.event.inputs.version }}"
+          echo "🔗 npm: https://www.npmjs.com/package/@fevertokens/packages/v/${{ github.event.inputs.version }}"

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -46,14 +46,17 @@ jobs:
         run: |
           npm version ${{ github.event.inputs.version }} --no-git-tag-version
 
-      - name: Build
-        run: npm run build
+      - name: Compile contracts
+        run: npm run compile
 
-      - name: Run checks
-        run: npm run check
+      - name: Run linters
+        run: npm run lint
+
+      - name: Run format check
+        run: npm run format:check
 
       - name: Publish to npm (latest tag)
-        run: npm publish --tag latest
+        run: npm publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -79,14 +82,17 @@ jobs:
 
             ### Installation
             ```bash
-            npm install -g @fevertokens/packages
+            npm install @fevertokens/packages
             # Or specific version
-            npm install -g @fevertokens/packages@${{ github.event.inputs.version }}
+            npm install @fevertokens/packages@${{ github.event.inputs.version }}
             ```
 
-            ### Verify Installation
-            ```bash
-            fever --version
+            ### Usage
+            ```solidity
+            // SPDX-License-Identifier: Apache-2.0
+            pragma solidity ^0.8.26;
+
+            import "@fevertokens/packages/contracts/token/ERC20/IERC20.sol";
             ```
 
             ${{ github.event.inputs.release-notes }}
@@ -100,8 +106,8 @@ jobs:
           echo "✅ Successfully published stable version: ${{ github.event.inputs.version }}"
           echo ""
           echo "📦 Install with:"
-          echo "   npm install -g @fevertokens/packages"
-          echo "   npm install -g @fevertokens/packages@${{ github.event.inputs.version }}"
+          echo "   npm install @fevertokens/packages"
+          echo "   npm install @fevertokens/packages@${{ github.event.inputs.version }}"
           echo ""
           echo "🔗 GitHub Release: https://github.com/${{ github.repository }}/releases/tag/v${{ github.event.inputs.version }}"
           echo "🔗 npm: https://www.npmjs.com/package/@fevertokens/packages/v/${{ github.event.inputs.version }}"

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version number (e.g., 0.1.0, 1.0.0)"
+        description: 'Version number (e.g., 0.1.0, 1.0.0)'
         required: true
         type: string
       release-notes:
-        description: "Release notes (optional)"
+        description: 'Release notes (optional)'
         required: false
         type: string
 
@@ -29,8 +29,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Validate version format
         run: |

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,45 @@
+# Development files
+.github/
+.git/
+.husky/
+scripts/
+
+# Build artifacts
+cache/
+artifacts/
+coverage/
+typechain/
+typechain-types/
+node_modules/
+
+# Configuration files
+.eslintrc
+.eslintignore
+.prettierrc
+.prettierignore
+.solhint.json
+hardhat.config.ts
+tsconfig.json
+
+# Documentation and guides
+CONTRIBUTING.md
+DCO
+.github/
+.git/
+
+# Environment and local files
+.env
+.env.*
+.DS_Store
+.idea/
+*.log
+.generatedWallet
+.privateKeyDeploy
+
+# Test files (if added in the future)
+test/
+tests/
+*.test.ts
+*.test.js
+*.spec.ts
+*.spec.js

--- a/contracts/diamond/view/PackageViewerInternal.sol
+++ b/contracts/diamond/view/PackageViewerInternal.sol
@@ -41,7 +41,7 @@ abstract contract PackageViewerInternal is IPackageViewerInternal {
                             numFacetSelectors[facetIndex]
                         ] = selector;
                         // probably will never have more than 256 functions from one facet contract
-                        require(numFacetSelectors[facetIndex] < 255);
+                        require(numFacetSelectors[facetIndex] < 255, 'PackageViewer: max selectors per facet exceeded');
                         numFacetSelectors[facetIndex]++;
                         continueLoop = true;
                         break;

--- a/contracts/diamond/view/PackageViewerInternal.sol
+++ b/contracts/diamond/view/PackageViewerInternal.sol
@@ -41,7 +41,10 @@ abstract contract PackageViewerInternal is IPackageViewerInternal {
                             numFacetSelectors[facetIndex]
                         ] = selector;
                         // probably will never have more than 256 functions from one facet contract
-                        require(numFacetSelectors[facetIndex] < 255, 'PackageViewer: max selectors per facet exceeded');
+                        require(
+                            numFacetSelectors[facetIndex] < 255,
+                            'PackageViewer: max selectors per facet exceeded'
+                        );
                         numFacetSelectors[facetIndex]++;
                         continueLoop = true;
                         break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fevertokens/packages",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fevertokens/packages",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^5.4.0"
@@ -953,6 +953,7 @@
       "integrity": "sha512-zhOZ4hdRORls31DTOqg+GmEZM0ujly8GGIuRY7t7szEk2zW/arY1qDug/py8AEktT00v5K+b6RvbVog+va51IA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "lodash.isequal": "^4.5.0"
@@ -1432,6 +1433,7 @@
       "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1518,6 +1520,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1713,6 +1716,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1924,7 +1928,6 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -2818,6 +2821,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3182,6 +3186,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -3640,6 +3645,7 @@
       "integrity": "sha512-xnORx1LgX46TxylOFme96JmSAIjXuHUVpOlUnaCt8MKMGsgy0NGsfPo5rJI/ncCBPLFLURGfZUQ2Uc6ZYN4kYg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",
         "@ethersproject/abi": "^5.1.2",
@@ -4462,7 +4468,6 @@
       "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
@@ -5015,7 +5020,6 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -5128,6 +5132,7 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6016,6 +6021,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6100,6 +6106,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6219,6 +6226,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "compile": "npx hardhat compile",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "format:fix": "prettier --write .",
     "lint": "npm run lint:ts && npm run lint:sol",
     "lint:ts": "eslint --ext .ts .",
+    "lint:ts:fix": "eslint --ext .ts . --fix",
     "lint:sol": "solhint \"contracts/**/*.sol\"",
     "prepack": "npm run compile"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@fevertokens/packages",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Modular, upgradeable smart contracts using a package-oriented framework built on the EIP-2535 Diamond Standard.",
+  "files": [
+    "/contracts/**/*.sol",
+    "/LICENSE",
+    "/README.md"
+  ],
   "scripts": {
     "local:node": "npx hardhat node",
     "clean": "npx hardhat clean",
@@ -10,11 +15,31 @@
     "format:check": "prettier --check .",
     "lint": "npm run lint:ts && npm run lint:sol",
     "lint:ts": "eslint --ext .ts .",
-    "lint:sol": "solhint \"contracts/**/*.sol\""
+    "lint:sol": "solhint \"contracts/**/*.sol\"",
+    "prepack": "npm run compile"
   },
-  "keywords": [],
-  "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FeverTokens/packages.git"
+  },
+  "keywords": [
+    "solidity",
+    "ethereum",
+    "smart-contracts",
+    "diamond-standard",
+    "eip-2535",
+    "upgradeable",
+    "modular",
+    "fevertokens",
+    "proxy",
+    "facets"
+  ],
+  "author": "FeverTokens",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/FeverTokens/packages/issues"
+  },
+  "homepage": "https://github.com/FeverTokens/packages#readme",
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fevertokens/packages",
-  "version": "0.0.1-rc.1",
+  "version": "0.0.1",
   "description": "Modular, upgradeable smart contracts using a package-oriented framework built on the EIP-2535 Diamond Standard.",
   "files": [
     "/contracts/**/*.sol",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fevertokens/packages",
-  "version": "0.0.1",
+  "version": "0.0.1-rc.1",
   "description": "Modular, upgradeable smart contracts using a package-oriented framework built on the EIP-2535 Diamond Standard.",
   "files": [
     "/contracts/**/*.sol",


### PR DESCRIPTION
This pull request introduces a new workflow for publishing stable releases to npm, along with supporting documentation and templates to standardize the release process. The main changes include adding a GitHub Actions workflow for publishing, a detailed release guide, and a new pull request template to improve consistency and clarity.

**Release automation and documentation improvements:**

* Added a new GitHub Actions workflow (`.github/workflows/publish-stable.yml`) to automate publishing stable releases to npm, including version validation, building, running checks, publishing, tagging, and creating GitHub Releases.
* Added a comprehensive release guide (`.github/RELEASE_GUIDE.md`) with step-by-step instructions for publishing, required setup, semantic versioning examples, and common npm commands.
* Introduced a new pull request template (`.github/PULL_REQUEST_TEMPLATE.md`) to standardize PR descriptions, change summaries, testing details, and checklists.